### PR TITLE
fix a problem of netty-session-factory

### DIFF
--- a/client/src/hornetq_clj/core_client.clj
+++ b/client/src/hornetq_clj/core_client.clj
@@ -189,8 +189,8 @@
                                            {"host" host "port" port})]
     (-> (HornetQClient/createServerLocatorWithoutHA
          (into-array TransportConfiguration [transport]))
-        .createSessionFactory
-        (doto (.setReconnectAttempts -1)))))
+         (doto (.setReconnectAttempts -1))
+        .createSessionFactory)))
 
 (defn in-vm-session-factory
   "Create a session factory for an in VM server."


### PR DESCRIPTION
The method (netty-session-factory) has a bug, and cannot work.
This is a fix.

Reason:
the setReconnectAttempts is a method of ServerLocator, 
not ClientSessionFactory , so the invoke order of (.setReconnectAttempts -1)
and (.createSessionFactory) must be swapped. 
