### PR TITLE
Fix server option handling; support persistenceEnabled option

### DIFF
--- a/server/src/hornetq_clj/server.clj
+++ b/server/src/hornetq_clj/server.clj
@@ -43,10 +43,10 @@
   "org.hornetq.core.remoting.impl.invm.InVMAcceptorFactory")
 
 (defn server
-  [{:keys [connectors acceptors netty stomp in-vm] :as options}]
+  [{:keys [netty stomp in-vm] :as options}]
   (make-server (merge-with
                 conj
-                (select-keys options [:connectors :acceptors])
+                options
                 {:connectors (filter
                               identity
                               [(when (or stomp netty)

--- a/server/src/hornetq_clj/server.clj
+++ b/server/src/hornetq_clj/server.clj
@@ -20,8 +20,9 @@
 
 (defn make-server
   "Create a hornetq server"
-  [{:keys [acceptors connectors journal-type security-enabled]
+  [{:keys [acceptors connectors journal-type security-enabled persistence-enabled]
     :or {security-enabled true
+         persistence-enabled true
          journal-type default-journal-type}}]
   (HornetQServers/newHornetQServer
    (doto (ConfigurationImpl.)
@@ -32,7 +33,8 @@
             (map #(vector (:name %) (transport-configuration (dissoc % :name)))
                  connectors)))
      (.setJournalType (Enum/valueOf JournalType (name journal-type)))
-     (.setSecurityEnabled (boolean security-enabled)))))
+     (.setSecurityEnabled (boolean security-enabled))
+     (.setPersistenceEnabled (boolean persistence-enabled)))))
 
 (def netty-connector-factory
   "org.hornetq.core.remoting.impl.netty.NettyConnectorFactory")


### PR DESCRIPTION
The server function was throwing away all options except `:connectors` and `:acceptors`. This pull request fixes that issue, adds default option values, and includes support for the 'persistenceEnabled' configuration setting.
