### PR TITLE
updated hornetq dependencies for compatibility with recent datomic-pro

### DIFF
--- a/client/project.clj
+++ b/client/project.clj
@@ -1,10 +1,10 @@
-(defproject hornetq-clj/client "0.2.1"
+(defproject hornetq-clj/client "0.2.1-LENTZ"
   :description "Simplify using hornetq server"
   :url "https://github.com/hugoduncan/hornetq-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.2.1"]
-                 [org.hornetq/hornetq-core-client "2.2.18.Final"]
+                 [org.hornetq/hornetq-core-client "2.3.17.Final"]
                  [org.jboss.netty/netty "3.2.1.Final"]]
   :repositories {"JBoss releases"
                  "http://repository.jboss.org/nexus/content/groups/public-jboss/"})

--- a/lein-hornetq/project.clj
+++ b/lein-hornetq/project.clj
@@ -1,8 +1,8 @@
-(defproject hornetq-clj/lein-hornetq "0.2.1"
+(defproject hornetq-clj/lein-hornetq "0.2.1-LENTZ"
   :description "lein hornetq server"
   :url "https://github.com/hugoduncan/hornetq-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.2.1"]
-                 [hornetq-clj/server "0.2.1"]]
+                 [hornetq-clj/server "0.2.1-LENTZ"]]
   :eval-in-leiningen true)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hornetq-clj "0.2.1"
+(defproject hornetq-clj "0.2.1-LENTZ"
   :description "hornetq clj interface"
   :url "https://github.com/hugoduncan/hornetq-clj"
   :license {:name "Eclipse Public License"

--- a/server/project.clj
+++ b/server/project.clj
@@ -1,11 +1,11 @@
-(defproject hornetq-clj/server "0.2.1"
+(defproject hornetq-clj/server "0.2.1-LENTZ"
   :description "Simplify using hornetq server"
   :url "https://github.com/hugoduncan/hornetq-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.2.1"]
-                 [org.hornetq/hornetq-core "2.2.18.Final"]
-                 [org.hornetq/hornetq-logging "2.2.18.Final"]
+                 [org.hornetq/hornetq-core "2.2.21.Final"]
+                 [org.hornetq/hornetq-logging "2.2.21.Final"]
                  [org.jboss.netty/netty "3.2.1.Final"]]
   :repositories {"JBoss releases"
                  "http://repository.jboss.org/nexus/content/groups/public-jboss/"})


### PR DESCRIPTION
Without these, the conflict in dependencies renders the peer library of recent datomic-pro distributions unable to connect due to an error involving trust-store when creating hornetq connections.
